### PR TITLE
fix: make RSD env template file work

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ rsd_working_directory: "/opt/rsd"
 rsd_version: "master"
 
 # Inventory specific environment file
-rsd_environment_file: "rsd-secrets.env"
+rsd_environment_file: "rsd-secrets.env.j2"
 
 # TLS certificate file
 rsd_tls_cert_file: "rsd.pem"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     recurse: yes
 
 - name: "Copy environment file"
-  ansible.builtin.copy:
+  ansible.builtin.template:
     src: "{{ rsd_environment_file }}"
     dest: "{{ (rsd_working_directory, 'rsd-secrets.env') | path_join }}"
     owner: "root"


### PR DESCRIPTION
Multiple issues prevented the RSD environment template file from being used:
* replace the wrong `copy` module with `template` module
* use the correct template file name in variable defaults

- Closes #9 