### PR TITLE
Change package management tool named in CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ After cloning the project locally the _Python_ dependencies need to be
 installed:
 
 ```shell
-$ pipenv install --dev
+$ poetry install
 ```
 
 As mentioned in the suggested contribution workflow above, linting and testing
@@ -138,7 +138,7 @@ and
 [yamllint rules](https://yamllint.readthedocs.io/en/stable/rules.html):
 
 ```shell
-$ pipenv run molecule lint
+$ poetry run molecule lint
 ```
 
 ### REUSE Specification Compliance
@@ -149,7 +149,7 @@ copyright information and that it thereby meets the
 [REUSE Specification](https://reuse.software/spec/):
 
 ```shell
-$ pipenv run reuse lint
+$ poetry run reuse lint
 ```
 
 ### Testing the Ansible Role
@@ -161,7 +161,7 @@ the existing automated test cases to verify that your changes do not break
 existing test cases:
 
 ```shell
-$ pipenv run molecule test
+$ poetry run molecule test
 ````
 
 ## How are Contributors Given Credit for Their Valuable Work?


### PR DESCRIPTION
* In this Ansible role project poetry is used in favour of pipenv.