### PR TITLE
Ignore errors during initials dry-run

### DIFF
--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -4,17 +4,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+- name: "Get stats of RSD working directory"
+  ansible.builtin.stat:
+    path: "{{ rsd_working_directory }}"
+  register: "working_directory"
+
+- name: "Determine if this is an initial dry-run"
+  ansible.builtin.set_fact:
+    is_initial_dryrun: "{{ ansible_check_mode and not working_directory.stat.exists }}"
+
 - name: "Check for python modules"
   community.general.python_requirements_info:
     dependencies: "{{ rsd_dependencies }}"
   register: "python_requirements"
 
 - name: "Assert that required python modules are available"
-  ansible.builtin.assert:
+  ansible.builtin.assert:  # noqa ignore-errors
     that:
       - "item in python_requirements.valid"
     fail_msg: "Python module '{{ item }}' is missing!"
   loop: "{{ rsd_dependencies }}"
+  ignore_errors: "{{ is_initial_dryrun }}"
 
 - name: "Get stats of TLS certificate"
   ansible.builtin.stat:
@@ -27,11 +37,12 @@
   register: "tls_key"
 
 - name: "Assert that required TLS files are present"
-  ansible.builtin.assert:
+  ansible.builtin.assert:  # noqa ignore-errors
     that:
       - "tls_cert.stat.exists"
       - "tls_key.stat.exists"
     fail_msg: "TLS certificate and/or private key missing!"
+  ignore_errors: "{{ is_initial_dryrun }}"
 
 - name: "Get stats of DH parameters file"
   ansible.builtin.stat:
@@ -41,14 +52,5 @@
 - name: "Determine if DH parameters file needs to be created"
   ansible.builtin.set_fact:
     create_dhparam_file: "{{ not dhparam_file.stat.exists }}"
-
-- name: "Get stats of RSD working directory"
-  ansible.builtin.stat:
-    path: "{{ rsd_working_directory }}"
-  register: "working_directory"
-
-- name: "Determine if this is an initial dry-run"
-  ansible.builtin.set_fact:
-    is_initial_dryrun: "{{ ansible_check_mode and not working_directory.stat.exists }}"
 
 ...


### PR DESCRIPTION
With this PR errors in an initial dry-run during the preflight checks will be ignored. 

* closes #49 