### PR TITLE
Adds support for Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Currently [supported platforms](meta/main.yml) are:
 - `rsd_nginx_dhparam_file_path`
   - Default: `"/etc/ssl/private/dhparam.pem"`
   - Description: Absolute destination path for DH parameters file.
+- `rsd_swagger_enabled`
+  - Default: `false`
+  - Description: Whether Swagger is enabled or not.
+- `rsd_swagger_version`
+  - Default: `v4.15.0`
+  - Description: version of of the Docker image `swaggerapi/swagger-ui`.
 - `rsd_prune_volumes`
   - Default: `false`
   - Description: Set to `true` to remove docker data volumes (**this will force container recreation**).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,10 @@ rsd_tls_key_path: "/etc/ssl/private/rsd.key"
 # Absolute destination path for DH parameters file
 rsd_nginx_dhparam_file_path: "/etc/ssl/private/dhparam.pem"
 
+# Swagger settings
+rsd_swagger_enabled: false
+rsd_swagger_version: "v4.15.0"
+
 # Software spotlights migration container image
 rsd_spotlight_migration_image: "ghcr.io/hifis-net/rsd-spotlight-migration:v1.0.0"
 

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -120,6 +120,19 @@ services:
       - net
     restart: unless-stopped
 
+{% if rsd_swagger_enabled | default(false) | bool %}
+  swagger:
+    image: swaggerapi/swagger-ui:{{ rsd_swagger_version }}
+    expose:
+      - 8080
+    environment:
+      - API_URL=${POSTGREST_URL_EXTERNAL}
+      - SUPPORTED_SUBMIT_METHODS=[]
+    networks:
+      - net
+    restart: unless-stopped
+{% endif %}
+
   nginx:
     image: {{ rsd_container_registry_path }}/nginx:{{ rsd_version }}
     ports:
@@ -130,6 +143,9 @@ services:
       - backend
       - auth
       - frontend
+{% if rsd_swagger_enabled | default(false) | bool%}
+      - swagger
+{% endif %}
     networks:
       - net
     volumes:

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 # SPDX-FileCopyrightText: 2022 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -100,4 +101,11 @@ server {
         proxy_set_header Accept application/octet-stream;
         proxy_pass http://backend/;
     }
+
+{% if rsd_swagger_enabled | default(false) | bool %}
+    # Provide user interface for API access
+    location /swagger/ {
+        proxy_pass http://swagger:8080/;
+    }
+{% endif %}
 }

--- a/templates/rsd-secrets.env.j2
+++ b/templates/rsd-secrets.env.j2
@@ -31,6 +31,10 @@ PGRST_SERVER_PORT=3500
 # consumed by services: authentication,frontend,auth-tests, scrapers
 POSTGREST_URL=http://backend:3500
 
+# postgREST API reachable outside of Docker
+# consumed by services: swagger
+POSTGREST_URL_EXTERNAL=https://{{ rsd_domain }}/api/v1
+
 # RSD Auth module
 # consumed by services: frontend (api/fe)
 RSD_AUTH_URL=http://auth:7000


### PR DESCRIPTION
Closes #118

Adds support for Swagger UI. The Docker image will be pulled directly from the original Docker Hub registry. By default, the service will be disabled and it can be enabled by setting `rsd_swagger_enabled`.

I hope I put everything to the right place. @Normo @tobiashuste may you please have a look?